### PR TITLE
Update courier dependency to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project attempts to follow [Semantic Versioning](http://semver.org/spec
 
 ## Unreleased
 
+### Removed
+
+* Dropped support for Courier 0.4 and 0.5
+
+### Changed
+
+* Added support for Courier 0.6
+
 ## 0.1.1 - 2018-12-10
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
         "psr/log": "^1.0",
-        "quartzy/courier": "^0.4.0|^0.5.0",
+        "quartzy/courier": "^0.6.0",
         "wildbit/postmark-php": "^2.3"
     },
     "require-dev": {

--- a/src/PostmarkCourier.php
+++ b/src/PostmarkCourier.php
@@ -48,7 +48,6 @@ class PostmarkCourier implements ConfirmingCourier
     protected function supportedContent(): array
     {
         return [
-            Content\EmptyContent::class,
             Content\Contracts\SimpleContent::class,
             Content\Contracts\TemplatedContent::class,
         ];
@@ -94,10 +93,6 @@ class PostmarkCourier implements ConfirmingCourier
                 break;
 
             case $content instanceof Content\SimpleContent:
-                $response = $this->sendNonTemplateEmail($email);
-                break;
-
-            case $content instanceof Content\EmptyContent:
                 $response = $this->sendNonTemplateEmail($email);
                 break;
 

--- a/tests/PostmarkCourierIntegrationTest.php
+++ b/tests/PostmarkCourierIntegrationTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Camuthig\Courier\Postmark\Test;
 
-use Courier\PostmarkCourier;
-use Courier\SparkPostCourier;
+use Camuthig\Courier\Postmark\PostmarkCourier;
 use PhpEmail\Attachment\FileAttachment;
 use PhpEmail\Content\SimpleContent;
 use PhpEmail\Content\TemplatedContent;
@@ -24,7 +23,7 @@ class PostmarkCourierIntegrationTest extends IntegrationTestCase
     private static $file = '/tmp/sparkpost_attachment_test.txt';
 
     /**
-     * @var SparkPostCourier
+     * @var PostmarkCourier
      */
     private $courier;
 
@@ -72,7 +71,7 @@ class PostmarkCourierIntegrationTest extends IntegrationTestCase
         self::assertEquals(getenv('POSTMARK_SENDER'), $message->getHeaderValue('from'));
         self::assertEquals($this->getTo(), $message->getHeaderValue('to'));
         self::assertEquals($this->getCc(), $message->getHeaderValue('cc'));
-        self::stringStartsWith('HTML', $message->getHtmlContent());
+        self::assertStringStartsWith('HTML', $message->getHtmlContent());
         self::assertEquals('text', trim($message->getTextContent()));
         self::assertHasAttachmentWithContentId($message, 'embed-test');
         self::assertHasAttachmentWithName($message, 'Attached File');
@@ -84,7 +83,7 @@ class PostmarkCourierIntegrationTest extends IntegrationTestCase
         self::assertEquals(getenv('POSTMARK_SENDER'), $message->getHeaderValue('from'));
         self::assertEquals($this->getTo(), $message->getHeaderValue('to'));
         self::assertEquals($this->getCc(), $message->getHeaderValue('cc'));
-        self::stringStartsWith('HTML', $message->getHtmlContent());
+        self::assertStringStartsWith('HTML', $message->getHtmlContent());
         self::assertEquals('text', trim($message->getTextContent()));
         self::assertHasAttachmentWithContentId($message, 'embed-test');
         self::assertHasAttachmentWithName($message, 'Attached File');
@@ -119,7 +118,7 @@ class PostmarkCourierIntegrationTest extends IntegrationTestCase
         self::assertEquals($subject, $message->getHeaderValue('subject'));
         self::assertEquals($this->getTo(), $message->getHeaderValue('to'));
         self::assertEquals($this->getCc(), $message->getHeaderValue('cc'));
-        self::stringStartsWith('HTML', $message->getHtmlContent());
+        self::assertStringStartsWith('HTML', $message->getHtmlContent());
         self::assertEquals('text', trim($message->getTextContent()));
         self::assertHasAttachmentWithContentId($message, 'embed-test');
         self::assertHasAttachmentWithName($message, 'Attached File');

--- a/tests/PostmarkCourierTest.php
+++ b/tests/PostmarkCourierTest.php
@@ -10,7 +10,6 @@ use Courier\Exceptions\TransmissionException;
 use Courier\Exceptions\UnsupportedContentException;
 use Mockery;
 use PhpEmail\Attachment\FileAttachment;
-use PhpEmail\Content\EmptyContent;
 use PhpEmail\Content\SimpleContent;
 use PhpEmail\Content\TemplatedContent;
 use PhpEmail\EmailBuilder;
@@ -108,46 +107,6 @@ class PostmarkCourierTest extends TestCase
     }
 
     /**
-     * @testdox It should send an email with no content
-     */
-    public function testSendsEmptyEmail()
-    {
-        /** @var Mockery\Mock|PostmarkClient $client */
-        $client = Mockery::mock(PostmarkClient::class);
-
-        $courier = new PostmarkCourier($client);
-
-        $email = EmailBuilder::email()
-            ->from('sender@test.com', 'Sender')
-            ->to('receiver@test.com')
-            ->withSubject('Test From Postmark API')
-            ->withContent(new EmptyContent())
-            ->build();
-
-        $client
-            ->shouldReceive('sendEmail')
-            ->once()
-            ->with(
-                '"Sender" <sender@test.com>',
-                'receiver@test.com',
-                'Test From Postmark API',
-                'No message',
-                'No message',
-                null,
-                true,
-                null,
-                null,
-                null,
-                [],
-                [],
-                null
-            )
-            ->andReturn($this->success());
-
-        $courier->deliver($email);
-    }
-
-    /**
      * @testdox It should send an email with templated content
      */
     public function testSendsTemplatedEmail()
@@ -230,7 +189,7 @@ class PostmarkCourierTest extends TestCase
             ->from('sender@test.com', 'Sender')
             ->to('receiver@test.com')
             ->withSubject('Test From Postmark API')
-            ->withContent(new EmptyContent())
+            ->withContent(SimpleContent::text(''))
             ->build();
 
         $exception                       = new PostmarkException();
@@ -245,8 +204,8 @@ class PostmarkCourierTest extends TestCase
                 '"Sender" <sender@test.com>',
                 'receiver@test.com',
                 'Test From Postmark API',
-                'No message',
-                'No message',
+                '',
+                null,
                 null,
                 true,
                 null,


### PR DESCRIPTION
This update requires removing support for the EmptyContent type as well
as ensuring templated emails can be sent with a null subject.